### PR TITLE
Use 127.0.0.1 as the default host

### DIFF
--- a/R/httpgd.R
+++ b/R/httpgd.R
@@ -26,7 +26,7 @@
 #'
 #' @export
 httpgd <-
-  function(host = "localhost",
+  function(host = "127.0.0.1",
            port = 8288,
            width = 720,
            height = 576,

--- a/inst/www/index.html
+++ b/inst/www/index.html
@@ -58,7 +58,7 @@
   </div>
   <script>
 
-    const svr = /*SRVRPARAMS*/{ "host": "localhost", "port": 8288, "upid": 1, "width": 736.000000, "height": 590.720020, "recording": true, "hsize": 0, "hindex": -1 }/**/;
+    const svr = /*SRVRPARAMS*/{ "host": "127.0.0.1", "port": 8288, "upid": 1, "width": 736.000000, "height": 590.720020, "recording": true, "hsize": 0, "hindex": -1 }/**/;
 
     const intervall_check = 1500;
     const baseapi = 'http://' + svr.host + ':' + svr.port;

--- a/man/httpgd.Rd
+++ b/man/httpgd.Rd
@@ -5,7 +5,7 @@
 \title{Initialize httpgd graphics device and start server.}
 \usage{
 httpgd(
-  host = "localhost",
+  host = "127.0.0.1",
   port = 8288,
   width = 720,
   height = 576,


### PR DESCRIPTION
Close #3.

This PR uses `127.0.0.1` as the default host, consistent with R help http server and shiny.