### PR TITLE
Print the actual hostname for 0.0.0.0

### DIFF
--- a/R/httpgd.R
+++ b/R/httpgd.R
@@ -151,7 +151,7 @@ httpgdClear <- function(which = dev.cur()) {
 httpgdURL <- function(endpoint = "live", which = dev.cur()) {
   l <- httpgdState(which)
   paste0("http://",
-         l$host,
+         sub('0.0.0.0', Sys.info()[['nodename']], l$host, fixed = TRUE),
          ":",
          l$port,
          "/",


### PR DESCRIPTION
When binding to `0.0.0.0` the server is accessible via `hostname`.