### PR TITLE
Fix missing newline in printing url

### DIFF
--- a/R/httpgd.R
+++ b/R/httpgd.R
@@ -62,7 +62,9 @@ httpgd <-
     aliases <- validate_aliases(system_fonts, user_fonts)
     if (httpgd_(host, port, bg, width, height, pointsize, aliases, cors, tok, webserver, silent)) {
       if (!silent && webserver) {
-        cat(paste0("httpgd server running at:\n  ", hyperrefstyle(httpgdURL(websockets=websockets))))
+        cat("httpgd server running at:\n  ",
+          hyperrefstyle(httpgdURL(websockets = websockets)),
+          "\n", sep = "")
       }
     } else {
       httpgdCloseServer()


### PR DESCRIPTION
In VSCode, port mapping in webview under remote development has been broken for quite a while due to upstream issue https://github.com/microsoft/vscode/issues/102449.

The latest VSCode supports auto port-mapping if a URL with port specified is captured in terminal output.

<img width="734" alt="image" src="https://user-images.githubusercontent.com/4662568/96745004-352eaa80-13f8-11eb-9dd4-b1589623551a.png">

Both httpgd and shiny show the url to browse before calling `browseURL()` but unfortunately some other packages do not do the same, so is the native `?` to show the html help.

To walk-around this problem, I need to always print out the browsing URL before sending browser request to vscode-R session watcher as implemented in https://github.com/Ikuyadeu/vscode-R/pull/427 so that VSCode could capture the port in url to perform the port-mapping for the WebView to show properly.

The current message is missing a `\n` so the two messages are mixed up together:

<img width="594" alt="image" src="https://user-images.githubusercontent.com/4662568/96811438-7e114e00-144e-11eb-8af5-15524e36453e.png">

This PR is a simple fix of the `http server running at: ` message so that it will look better:

<img width="329" alt="image" src="https://user-images.githubusercontent.com/4662568/96812815-e2341200-144e-11eb-9f79-2c40d8c6f54e.png">


