### PR TITLE
include browser argument in the `hgd_browse` function

### DIFF
--- a/R/httpgd.R
+++ b/R/httpgd.R
@@ -413,6 +413,7 @@ hgd_url <- function(
 #'
 #' @param ... Parameters passed to [hgd_url()].
 #' @param which Which device (ID).
+#' @param browser Program to be used as HTML browser.
 #'
 #' @return URL.
 #'
@@ -429,8 +430,11 @@ hgd_url <- function(
 #'
 #' dev.off()
 #' }
-hgd_browse <- function(..., which = dev.cur()) {
-  browseURL(hgd_url(..., which = which))
+hgd_browse <- function(..., which = dev.cur(), browser = NULL) {
+  if (is.null(browser)) {
+    browser <- getOption("browser")
+  }
+  browseURL(hgd_url(..., which = which), browser)
 }
 
 #' Close httpgd device.

--- a/man/hgd_browse.Rd
+++ b/man/hgd_browse.Rd
@@ -4,12 +4,14 @@
 \alias{hgd_browse}
 \title{Open httpgd URL in the browser.}
 \usage{
-hgd_browse(..., which = dev.cur())
+hgd_browse(..., which = dev.cur(), browser = NULL)
 }
 \arguments{
 \item{...}{Parameters passed to \code{\link[=hgd_url]{hgd_url()}}.}
 
 \item{which}{Which device (ID).}
+
+\item{browser}{Program to be used as HTML browser.}
 }
 \value{
 URL.


### PR DESCRIPTION
Hey @nx10, thanks for this package. This package is an awesome solution for vim/emacs users dealing with x11 windows in a non-interactive way.

This PR changes the `hgd_browse` function by including an argument to control in which browser opens the server. 

I made some tests changing R_BROWSER environmental variable for different browsers, but the original `hgd_browse` always uses my system default browser. Now, users can control this action by setting the browser name in the `browser` argument. Letting this argument empty, `hgd_browse` uses the browser defined in the R_BROWSER environmental variable. If this environmental variable also is empty, `hgd_browse` uses the system default browser.