### PR TITLE
Docs: add a document about use cases in docker containers

### DIFF
--- a/vignettes/a00_installation.Rmd
+++ b/vignettes/a00_installation.Rmd
@@ -46,3 +46,19 @@ unable to load shared object [...] systemfonts/libs/systemfonts.so [...]
 
 Install [`XQuartz`](https://www.xquartz.org/).
 (see: <https://github.com/r-lib/systemfonts/issues/17>)
+
+### Linux
+
+For source installation on Linux, the fontconfig freetype2 library is required to install the `systemfonts` package, which is a dependency of `httpgd`.
+
+#### Debian, Ubuntu, etc.
+
+```sh
+apt install libfontconfig1-dev
+```
+
+#### Fedora, CentOS, RHEL, etc.
+
+```sh
+dnf install fontconfig-devel
+```

--- a/vignettes/b03_docker.Rmd
+++ b/vignettes/b03_docker.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Docker (Linux containers)"
+title: "Docker"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Docker}
@@ -7,7 +7,7 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-Using `httpgd` to display R plots in a Docker container may be easier than the traditional and common method; linking the X11 window system.
+Using `httpgd` to display R plots in a Docker container (Linux container) may be easier than the traditional and common method; linking the X11 window system.
 
 ## Basic usage
 

--- a/vignettes/b03_docker.Rmd
+++ b/vignettes/b03_docker.Rmd
@@ -24,8 +24,8 @@ FROM r-base:latest
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     libfontconfig1-dev \
-    && apt autoremove -y && apt clean -y && rm -rf /var/lib/apt/lists/* \
-    && install2.r --error --sikipinstalled --ncpu -1 \
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* \
+    && install2.r --error --skipinstalled --ncpu -1 \
     httpgd \
     && rm -rf /tmp/downloaded_packages
 ```

--- a/vignettes/b03_docker.Rmd
+++ b/vignettes/b03_docker.Rmd
@@ -56,6 +56,9 @@ httpgd::hgd(host = "0.0.0.0", port = 8888)
 
 Then, copy the displayed link like in the browser.
 
+If you want to display the link again, execute the `hgd_url` function as follows.  
+The hostname can be replaced with any value (e.g. localhost).
+
 ```R
 httpgd::hgd_url(host = "localhost")
 ```

--- a/vignettes/b03_docker.Rmd
+++ b/vignettes/b03_docker.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Docker"
+title: "Docker (Linux containers)"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Docker}
@@ -7,4 +7,81 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-> TODO: How to use httpgd with Docker
+Using `httpgd` to display R plots in a Docker container may be easier than the traditional and common method; linking the X11 window system.
+
+## Basic usage
+
+### Build a docker image
+
+See the `vignette("a00_installation")` for details on how to install `httpgd` on Linux.
+
+You can create a Docker image with `httpgd` installed by create a Dockerfile like below.
+
+```Dockerfile
+FROM r-base:latest
+
+# Install httpgd and dependent packages.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    libfontconfig1-dev \
+    && apt autoremove -y && apt clean -y && rm -rf /var/lib/apt/lists/* \
+    && install2.r --error --sikipinstalled --ncpu -1 \
+    httpgd \
+    && rm -rf /tmp/downloaded_packages
+```
+
+Run the `docker build` command from your shell to build a Docker image.
+
+```sh
+docker build . -f Dockerfile -t httpgd:test
+```
+
+### Create a container
+
+When creating a container with the `docker run` command, bind the port to be used by `httpgd` with the `-p` (`--publish`) option.
+
+If you run R in a container with a command like the following, the 8888 port of the container will be bound to the 8888 port of the Docker host.
+
+```sh
+docker run --rm -it -p 8888:8888 httpgd:test R
+```
+
+### Start httpgd server
+
+Running the following command in the R console will initialize the graphics device and start the server.
+
+```R
+httpgd::hgd(host = "0.0.0.0", port = 8888)
+```
+
+Then, copy the displayed link like in the browser.
+
+```R
+httpgd::hgd_url(host = "localhost")
+```
+
+## Advanced usage
+
+### Set options in Rprofile
+
+By setting options `httpgd.host` and `httpgd.port` in the Rprofile, you can omit setting the arguments when starting the httpgd server by `hgd()`.
+
+For example, if you create a Dockerfile with the following contents, you can build an image with these options already set in the Rprofile.
+
+```Dockerfile
+FROM r-base:latest
+
+# Install httpgd and dependent packages.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    libfontconfig1-dev \
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* \
+    && install2.r --error --skipinstalled --ncpu -1 \
+    httpgd \
+    && rm -rf /tmp/downloaded_packages
+
+# Set default values used in the httpgd::hgd() function.
+RUN echo 'options(httpgd.host = "0.0.0.0", httpgd.port = 8888)' >> /etc/R/Rprofile.site
+
+EXPOSE 8888
+```


### PR DESCRIPTION
Related to #66.
I also added a note on how to install it on Linux.

When this is published, I'd like to link to it from[ the Rocker project wiki](https://github.com/rocker-org/rocker/wiki/Allowing-GUI-windows).

cc @wds15