### PR TITLE
Docs: fix linking and typo

### DIFF
--- a/vignettes/a00_installation.Rmd
+++ b/vignettes/a00_installation.Rmd
@@ -49,7 +49,7 @@ Install [`XQuartz`](https://www.xquartz.org/).
 
 ### Linux
 
-For source installation on Linux, the fontconfig freetype2 library is required to install the `systemfonts` package, which is a dependency of `httpgd`.
+For source installation on Linux, the fontconfig freetype2 library is required to install the `{systemfonts}` package, which is a dependency of `httpgd`.
 
 #### Debian, Ubuntu, etc.
 

--- a/vignettes/b03_docker.Rmd
+++ b/vignettes/b03_docker.Rmd
@@ -54,9 +54,9 @@ Running the following command in the R console will initialize the graphics devi
 httpgd::hgd(host = "0.0.0.0", port = 8888)
 ```
 
-Then, copy the displayed link like in the browser.
+Then, copy the displayed link in your browser.
 
-If you want to display the link again, execute the `hgd_url` function as follows.  
+If you want to display the link again, execute the `hgd_url()` function as follows.  
 The hostname can be replaced with any value (e.g. localhost).
 
 ```R


### PR DESCRIPTION
Update for [automatic linking to external packages](https://github.com/r-lib/pkgdown/blob/953a87771f74e405f2e648750b1b74db1806770a/vignettes/linking.Rmd#L36), linking to the functions, and fix typo.