### PR TITLE
Remove whitespace after operator""

### DIFF
--- a/src/lib/crow/common.h
+++ b/src/lib/crow/common.h
@@ -348,7 +348,7 @@ constexpr crow::HTTPMethod method_from_string(const char* str)
                                                            throw std::runtime_error("invalid http method");
 }
 
-constexpr crow::HTTPMethod operator"" _method(const char* str, size_t /*len*/)
+constexpr crow::HTTPMethod operator""_method(const char* str, size_t /*len*/)
 {
     return method_from_string( str );
 }


### PR DESCRIPTION
The space after `""` is deprecated since it creates ambiguity with reserved `_`-initial names per:

https://en.cppreference.com/w/cpp/language/user_literal

This might start throwing compiler warnings under `clang++-20`.