### PR TITLE
docs: fix typo 'seperate' -> 'separate' in NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,7 +42,7 @@
 
 # httpgd 2.0.0
 
-- Split graphics rendering and R interface to seperate package 'unigd'.
+- Split graphics rendering and R interface to separate package 'unigd'.
 - Large refactoring and rewrite.
 - Numerous fixes and improvements in 'unigd' (see 'NEWS.md' there).
 - Migrate to crow web server library (due to belle being deprecated).


### PR DESCRIPTION
This PR fixes a simple documentation typo:  →  in NEWS.md line 45.

No functional changes, just a small documentation fix.

## Summary
- Fixes a single documentation spelling error
- 1 file +1/-1 change