### PR TITLE
docs: fix typo (seperate->separate (x1))

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,7 +42,7 @@
 
 # httpgd 2.0.0
 
-- Split graphics rendering and R interface to seperate package 'unigd'.
+- Split graphics rendering and R interface to separate package 'unigd'.
 - Large refactoring and rewrite.
 - Numerous fixes and improvements in 'unigd' (see 'NEWS.md' there).
 - Migrate to crow web server library (due to belle being deprecated).


### PR DESCRIPTION
## Summary
Fixes spelling/typo issues found in this project's documentation.

**Details:** Fix documentation typos: seperate->separate (x1)

**Files:**
- `NEWS.md`

Documentation-only; no functional code changes.
